### PR TITLE
Rename `BaseRepository` to `Repository`

### DIFF
--- a/src/saticoy-core/repository/repository.ts
+++ b/src/saticoy-core/repository/repository.ts
@@ -1,13 +1,4 @@
-interface Repository<T> {
-    add(item: T, name: string, aliasses?: string[]): void;
-    remove(name: string): void;
-    get(name: string): T;
-    getAlias(name: string): T;
-    getNames(include_aliases?: boolean): string[];
-    hasName(name: string): boolean;
-}
-
-class BaseRepository<T> implements Repository<T> {
+class Repository<T> {
     private _items: { [key: string]: T } = {};
     private _aliasses: { [key: string]: string } = {};
 
@@ -58,4 +49,3 @@ class BaseRepository<T> implements Repository<T> {
 }
 
 export default Repository;
-export { BaseRepository };

--- a/src/saticoy-ui/globals/i18n.ts
+++ b/src/saticoy-ui/globals/i18n.ts
@@ -1,4 +1,4 @@
-import { BaseRepository } from "../../saticoy-core/repository/repository";
+import Repository from "../../saticoy-core/repository/repository";
 import { BrowserRetriever, LocalPreferencesRetriever } from "../../saticoy-core/internationalization/i18n-retriever";
 import { eventBus } from './eventbus'
 import { LocalPreferencesSaver } from "../../saticoy-core/internationalization/i18n-saver";
@@ -13,7 +13,7 @@ import { initReactI18next } from 'react-i18next';
 import HttpApi from 'i18next-http-backend';
 
 // Repository
-const localeRepo = new BaseRepository<i18NextLocaleData>();
+const localeRepo = new Repository<i18NextLocaleData>();
 localeRepo.add(en_US, "en-US", ["en"]);
 localeRepo.add(nl_NL, "nl-NL", ["nl"]);
 

--- a/src/saticoy-ui/globals/theme.ts
+++ b/src/saticoy-ui/globals/theme.ts
@@ -1,5 +1,5 @@
 import SaticoyChakraStyle from "../themes/saticoy-style";
-import { BaseRepository } from "../../saticoy-core/repository/repository";
+import Repository from "../../saticoy-core/repository/repository";
 import saticoy_theme from "../themes/saticoy";
 import saticoy_roboto_slab_theme from "../themes/saticoy-roboto-slab";
 import ThemeController from "../../saticoy-core/theme-controller/theme-controller";
@@ -9,7 +9,7 @@ import { eventBus } from './eventbus'
 import { LocalPreferencesSaver } from "../../saticoy-core/theme-controller/theme-saver";
 
 // Repository
-const themeRepo = new BaseRepository<Theme<SaticoyChakraStyle>>();
+const themeRepo = new Repository<Theme<SaticoyChakraStyle>>();
 themeRepo.add(saticoy_theme, "Saticoy");
 themeRepo.add(saticoy_roboto_slab_theme, "Saticoy (Roboto Slab)");
 

--- a/tests/test-i18n-controller.ts
+++ b/tests/test-i18n-controller.ts
@@ -1,6 +1,6 @@
 import I18nConroller from '../src/saticoy-core/internationalization/i18n-controller';
 import { LocaleData } from '../src/saticoy-core/internationalization/localedata';
-import Repository, { BaseRepository } from '../src/saticoy-core/repository/repository';
+import Repository from '../src/saticoy-core/repository/repository';
 import I18nRetriever from '../src/saticoy-core/internationalization/i18n-retriever';
 import I18nSaver from '../src/saticoy-core/internationalization/i18n-saver';
 
@@ -33,7 +33,7 @@ describe('I18nController', () => {
     let i18n_repository: Repository<LocaleData>;
 
     beforeEach(() => {
-        i18n_repository = new BaseRepository<LocaleData>();
+        i18n_repository = new Repository<LocaleData>();
         i18n_controller = new I18nConroller(
             i18n_repository,
             undefined,

--- a/tests/test-repository.ts
+++ b/tests/test-repository.ts
@@ -1,10 +1,10 @@
-import { BaseRepository } from '../src/saticoy-core/repository/repository';
+import Repository from '../src/saticoy-core/repository/repository';
 
-describe('BaseRepository', () => {
-    let repository: BaseRepository<number>;
+describe('Repository', () => {
+    let repository: Repository<number>;
 
     beforeEach(() => {
-        repository = new BaseRepository<number>();
+        repository = new Repository<number>();
     });
 
     it('Should add item', () => {

--- a/tests/test-theme-controller.ts
+++ b/tests/test-theme-controller.ts
@@ -1,4 +1,4 @@
-import { BaseRepository } from '../src/saticoy-core/repository/repository';
+import Repository from '../src/saticoy-core/repository/repository';
 import { Theme, Style, ThemeMode } from '../src/saticoy-core/theme-controller/theme';
 import ThemeController from '../src/saticoy-core/theme-controller/theme-controller';
 import ThemeRetriever from '../src/saticoy-core/theme-controller/theme-retriever';
@@ -59,7 +59,7 @@ const MockThemeLight: Theme = {
 }
 
 describe('Mode control', () => {
-    const repository = new BaseRepository<Theme<Style>>();
+    const repository = new Repository<Theme<Style>>();
     let controller: ThemeController<Style>;
 
     beforeEach(() => {
@@ -117,7 +117,7 @@ describe('Mode control', () => {
 });
 
 describe('Theme control', () => {
-    const repository = new BaseRepository<Theme<Style>>();
+    const repository = new Repository<Theme<Style>>();
     let controller: ThemeController<Style>;
 
     beforeEach(() => {
@@ -169,7 +169,7 @@ describe('Theme control', () => {
 });
 
 describe('Style retrieval', () => {
-    const repository = new BaseRepository<Theme<Style>>();
+    const repository = new Repository<Theme<Style>>();
     let controller: ThemeController<Style>;
 
     beforeEach(() => {
@@ -217,7 +217,7 @@ describe('Style retrieval', () => {
 });
 
 describe('Theme styles', () => {
-    const repository = new BaseRepository<Theme<Style>>();
+    const repository = new Repository<Theme<Style>>();
     let controller: ThemeController<Style>;
 
     beforeEach(() => {


### PR DESCRIPTION
The interface was not needed since we only use a normal `Repository`
anyway. If we ever need a class with the same signature, we can just
subclass the `Repository` class.

Fixes #54